### PR TITLE
posix: allow authenticating anywhere under the base_dn

### DIFF
--- a/lib/ldap_fluff/posix.rb
+++ b/lib/ldap_fluff/posix.rb
@@ -13,8 +13,8 @@ class LdapFluff::Posix
   end
 
   def bind?(uid=nil, password=nil)
-    @ldap.auth "uid=#{uid},#{@base}", password
-    @ldap.bind
+    @ldap.bind_as :filter   => "(uid=#{uid})",
+                  :password => password
   end
 
   def groups_for_uid(uid)

--- a/test/posix_test.rb
+++ b/test/posix_test.rb
@@ -49,15 +49,13 @@ class TestPosix < MiniTest::Test
   end
 
   def test_good_bind
-    @ldap.expect(:auth, nil, ["uid=internet,dc=internet,dc=com", "password"])
-    @ldap.expect(:bind, true)
+    @ldap.expect(:bind_as, true, [:filter => "(uid=internet)", :password => "password"])
     @posix.ldap = @ldap
     assert_equal @posix.bind?("internet", "password"), true
   end
 
   def test_bad_bind
-    @ldap.expect(:auth, nil, ["uid=internet,dc=internet,dc=com", "password"])
-    @ldap.expect(:bind, false)
+    @ldap.expect(:bind_as, false, [:filter => "(uid=internet)", :password => "password"])
     @posix.ldap = @ldap
     assert_equal @posix.bind?("internet", "password"), false
   end


### PR DESCRIPTION
bind_as will do a search using the provided filter (currently remaining hard-coded to UID) and then bind to the located DN.  This allows users to authenticate in environments where OUs under the base_dn contain the users, rather than the base_dn itself.
