### PR TITLE
Move foreman LDAP functionality to ldap_fluff

### DIFF
--- a/ldap_fluff.gemspec
+++ b/ldap_fluff.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ldap_fluff'
-  s.version     = '0.2.5'
+  s.version     = '0.3.0'
   s.summary     = 'LDAP Querying tools for Active Directory, FreeIPA and Posix-style'
   s.description = 'Simple library for binding & group querying on top of various ldap implementations'
   s.homepage    = 'https://github.com/Katello/ldap_fluff'
@@ -10,11 +10,15 @@ Gem::Specification.new do |s|
   s.test_files   = Dir['test/**/*.rb']
 
   s.has_rdoc = true
-  s.author   = 'Jordan OMara'
-  s.email    = 'jomara@redhat.com'
+  s.author   = %w('Jordan OMara' 'Daniel Lobato' 'Petr Chalupa', 'Adam Price' 'Marek Hulan')
+  s.email    = %w('jomara@redhat.com' 'elobatocs@gmail.com' 'pchalupa@redhat.com' 'komidore64@gmail.com' 'mhulan@redhat.com')
 
   s.add_dependency('net-ldap', '>= 0.3.1')
-  s.add_dependency('activesupport', '~> 3.2')
+  if RUBY_VERSION < '1.9'
+    s.add_dependency('activesupport', '~> 3.2')
+  else
+    s.add_dependency('activesupport')
+  end
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest')
 end

--- a/lib/ldap_fluff.rb
+++ b/lib/ldap_fluff.rb
@@ -1,5 +1,8 @@
+require 'ldap_fluff/error'
 require 'ldap_fluff/config'
 require 'ldap_fluff/ldap_fluff'
+require 'ldap_fluff/generic'
+require 'ldap_fluff/generic_member_service'
 require 'ldap_fluff/active_directory'
 require 'ldap_fluff/ad_member_service'
 require 'ldap_fluff/posix'

--- a/lib/ldap_fluff/config.rb
+++ b/lib/ldap_fluff/config.rb
@@ -1,90 +1,85 @@
 require 'yaml'
 require 'active_support/core_ext/hash'
 
-class LdapFluff
-  class ConfigError < StandardError
+class LdapFluff::Config
+  ATTRIBUTES = %w[host port encryption base_dn group_base server_type service_user
+                    service_pass anon_queries attr_login search_filter]
+  ATTRIBUTES.each { |attr| attr_reader attr.to_sym }
+
+  DEFAULT_CONFIG = { 'port'         => 389,
+                     'encryption'   => nil,
+                     'base_dn'      => 'dc=company,dc=com',
+                     'group_base'   => 'dc=company,dc=com',
+                     'server_type'  => :free_ipa,
+                     'anon_queries' => false }
+
+  def initialize(config)
+    raise ArgumentError unless config.respond_to?(:to_hash)
+    config = validate(convert(config))
+
+    ATTRIBUTES.each do |attr|
+      instance_variable_set(:"@#{attr}", config[attr])
+    end
   end
 
-  class Config
-    ATTRIBUTES = %w[host port encryption base_dn group_base server_type ad_domain service_user
-                    service_pass anon_queries]
-    ATTRIBUTES.each { |attr| attr_reader attr.to_sym }
+  private
 
-    DEFAULT_CONFIG = { 'port'         => 389,
-                       'encryption'   => nil,
-                       'base_dn'      => 'dc=company,dc=com',
-                       'group_base'   => 'dc=company,dc=com',
-                       'server_type'  => :free_ipa,
-                       'ad_domain'    => nil,
-                       'anon_queries' => false }
-
-    def initialize(config)
-      raise ArgumentError unless config.respond_to?(:to_hash)
-      config = validate(convert(config))
-
-      ATTRIBUTES.each do |attr|
-        instance_variable_set(:"@#{attr}", config[attr])
+  # @param [#to_hash] config
+  def convert(config)
+    config.to_hash.with_indifferent_access.tap do |conf|
+      %w[encryption server_type].each do |key|
+        conf[key] = conf[key].to_sym if conf[key]
       end
     end
+  end
 
-    private
+  def missing_keys?(config)
+    missing_keys = ATTRIBUTES - config.keys
+    raise ConfigError, "missing configuration for keys: #{missing_keys.join(',')}" unless missing_keys.empty?
+  end
 
-    # @param [#to_hash] config
-    def convert(config)
-      config.to_hash.with_indifferent_access.tap do |conf|
-        %w[encryption server_type].each do |key|
-          conf[key] = conf[key].to_sym if conf[key]
-        end
+  def unknown_keys?(config)
+    unknown_keys = config.keys - ATTRIBUTES
+    raise ConfigError, "unknown configuration keys: #{unknown_keys.join(',')}" unless unknown_keys.empty?
+  end
+
+  def all_required_keys?(config)
+    %w[host port base_dn group_base server_type].all? do |key|
+      raise ConfigError, "config key #{key} has to be set, it was nil" if config[key].nil?
+    end
+
+    %w[service_user service_pass].all? do |key|
+      if !config['anon_queries'] && config['server_type'] != :posix && config[key].nil?
+        raise ConfigError, "config key #{key} has to be set, it was nil"
       end
     end
+  end
 
-    def missing_keys?(config)
-      missing_keys = ATTRIBUTES - config.keys
-      raise ConfigError, "missing configuration for keys: #{missing_keys.join(',')}" unless missing_keys.empty?
+  def anon_queries_set?(config)
+    unless [false, true].include?(config['anon_queries'])
+      raise ConfigError, "config key anon_queries has to be true or false but was #{config['anon_queries']}"
     end
+  end
 
-    def unknown_keys?(config)
-      unknown_keys = config.keys - ATTRIBUTES
-      raise ConfigError, "unknown configuration keys: #{unknown_keys.join(',')}" unless unknown_keys.empty?
+  def correct_server_type?(config)
+    unless [:posix, :active_directory, :free_ipa].include?(config['server_type'])
+      raise ConfigError, 'config key server_type has to be :active_directory, :posix, :free_ipa ' +
+        "but was #{config['server_type']}"
     end
+  end
 
-    def all_required_keys?(config)
-      %w[host port base_dn group_base server_type].all? do |key|
-        raise ConfigError, "config key #{key} has to be set, it was nil" if config[key].nil?
-      end
+  def validate(config)
+    config = DEFAULT_CONFIG.merge(config)
 
-      %w[service_user service_pass].all? do |key|
-        if !config['anon_queries'] && config['server_type'] != :posix && config[key].nil?
-          raise ConfigError, "config key #{key} has to be set, it was nil"
-        end
-      end
-    end
+    correct_server_type?(config)
+    missing_keys?(config)
+    unknown_keys?(config)
+    all_required_keys?(config)
+    anon_queries_set?(config)
 
-    def anon_queries_set?(config)
-      unless [false, true].include?(config['anon_queries'])
-        raise ConfigError, "config key anon_queries has to be true or false but was #{config['anon_queries']}"
-      end
-    end
+    config
+  end
 
-    def correct_server_type?(config)
-      unless [:posix, :active_directory, :free_ipa].include?(config['server_type'])
-        raise ConfigError, 'config key server_type has to be :active_directory, :posix, :free_ipa ' +
-          "but was #{config['server_type']}"
-      end
-    end
-
-    def validate(config)
-      config = DEFAULT_CONFIG.merge(config)
-
-      correct_server_type?(config)
-      missing_keys?(config)
-      unknown_keys?(config)
-      all_required_keys?(config)
-      anon_queries_set?(config)
-
-      config
-    end
-
-  end # Config
-
-end # LdapFluff
+  class ConfigError < LdapFluff::Error
+  end
+end

--- a/lib/ldap_fluff/error.rb
+++ b/lib/ldap_fluff/error.rb
@@ -1,0 +1,5 @@
+class LdapFluff
+  class Error < StandardError
+  end
+end
+

--- a/lib/ldap_fluff/generic.rb
+++ b/lib/ldap_fluff/generic.rb
@@ -1,0 +1,75 @@
+class LdapFluff::Generic
+  attr_accessor :ldap, :member_service
+
+  def initialize(config = {})
+    @ldap = Net::LDAP.new(:host       => config.host,
+                          :base       => config.base_dn,
+                          :port       => config.port,
+                          :encryption => config.encryption)
+    @attr_login = config.attr_login
+    @group_base = (config.group_base.empty? ? config.base_dn : config.group_base)
+    @member_service = self.class::MemberService.new(@ldap, config)
+  end
+
+  def user_exists?(uid)
+    @member_service.find_user(uid)
+    true
+  rescue self.class::MemberService::UIDNotFoundException
+    false
+  end
+
+  def group_exists?(gid)
+    @member_service.find_group(gid)
+    true
+  rescue self.class::MemberService::GIDNotFoundException
+    false
+  end
+
+  def groups_for_uid(uid)
+    @member_service.find_user_groups(uid)
+  rescue self.class::MemberService::UIDNotFoundException
+    return []
+  end
+
+  def users_for_gid(gid)
+    return [] unless group_exists?(gid)
+    search = @member_service.find_group(gid).last
+
+    method = [:member, :ismemberof,
+              :memberof, :memberuid].find { |m| search.respond_to? m } or
+             raise 'Group does not have any members'
+
+    users_from_search_results(search, method)
+  end
+
+  def includes_cn?(cn)
+    filter = Net::LDAP::Filter.eq('cn', cn)
+    @ldap.search(:base => @ldap.base, :filter => filter).present?
+  end
+
+  def service_bind
+    unless @anon || bind?(@bind_user, @bind_pass)
+      raise UnauthenticatedException,
+            "Could not bind to #{class_name} user #{@bind_user}"
+    end
+  end
+
+  private
+  def class_name
+    self.class.name.split('::').last
+  end
+
+  def users_from_search_results(search, method)
+    members = search.send method
+    if method == :memberuid
+      # memberuid contains an array ['user1','user2'], no need to parse it
+      members
+    else
+      @member_service.get_logins(members)
+    end
+  end
+
+  class UnauthenticatedException < LdapFluff::Error
+  end
+end
+

--- a/lib/ldap_fluff/generic_member_service.rb
+++ b/lib/ldap_fluff/generic_member_service.rb
@@ -1,0 +1,62 @@
+require 'net/ldap'
+
+class LdapFluff::GenericMemberService
+
+  attr_accessor :ldap
+
+  def initialize(ldap, config)
+    @ldap       = ldap
+    @group_base = (config.group_base.empty? ? config.base_dn : config.group_base)
+    begin
+      @search_filter = Net::LDAP::Filter.construct(config.search_filter) unless (config.search_filter.nil? || config.search_filter.empty?)
+    rescue Net::LDAP::LdapError => error
+      puts "Search filter unavailable - #{error}"
+    end
+  end
+
+  def find_user(uid)
+    user = @ldap.search(:filter => name_filter(uid))
+    raise self.class::UIDNotFoundException if (user.nil? || user.empty?)
+    user
+  end
+
+  def find_group(gid)
+    group = @ldap.search(:filter => group_filter(gid), :base => @group_base)
+    raise self.class::GIDNotFoundException if (group.nil? || group.empty?)
+    group
+  end
+
+  def name_filter(uid)
+    filter = Net::LDAP::Filter.eq(@attr_login, uid)
+
+    if @search_filter.nil?
+      filter
+    else
+      filter & @search_filter
+    end
+  end
+
+  def group_filter(gid)
+    Net::LDAP::Filter.eq("cn", gid)
+  end
+
+  # extract the group names from the LDAP style response,
+  # return string will be something like
+  # CN=bros,OU=bropeeps,DC=jomara,DC=redhat,DC=com
+  def get_groups(grouplist)
+    grouplist.map(&:downcase).collect { |g| g.sub(/.*?cn=(.*?),.*/, '\1') }
+  end
+
+  def get_logins(userlist)
+    userlist.map(&:downcase!)
+    [@attr_login, 'uid', 'cn'].map do |attribute|
+      logins = userlist.collect { |g| g.sub(/.*?#{attribute}=(.*?),.*/, '\1') }
+      if logins == userlist
+        nil
+      else
+        logins
+      end
+    end.compact.flatten
+  end
+
+end

--- a/lib/ldap_fluff/ldap_fluff.rb
+++ b/lib/ldap_fluff/ldap_fluff.rb
@@ -18,15 +18,21 @@ class LdapFluff
     end
   end
 
-  # return true if the user password combination
-  # authenticates the user, otherwise false
   def authenticate?(uid, password)
     if password.nil? || password.empty?
-      # protect against passwordless auth from ldap server
-      return false
+      false
     else
-      @ldap.bind? uid, password
+      !!@ldap.bind?(uid, password)
     end
+  end
+
+  def test
+    @ldap.ldap.open {}
+  end
+
+  # return a list[] of users for a given gid
+  def user_list(gid)
+    @ldap.users_for_gid(gid)
   end
 
   # return a list[] of groups for a given uid
@@ -50,4 +56,13 @@ class LdapFluff
     @ldap.group_exists? gid
   end
 
+  # return ldap entry
+  def find_user(uid)
+    @ldap.member_service.find_user(uid)
+  end
+
+  # return ldap entry
+  def find_group(gid)
+    @ldap.member_service.find_group(gid)
+  end
 end

--- a/test/ad_member_services_test.rb
+++ b/test/ad_member_services_test.rb
@@ -4,9 +4,8 @@ class TestADMemberService < MiniTest::Test
   include LdapTestHelper
 
   def setup
-    config
-    @ldap    = MiniTest::Mock.new
-    @adms    = LdapFluff::ActiveDirectory::MemberService.new(@ldap, @config.group_base)
+    super
+    @adms    = LdapFluff::ActiveDirectory::MemberService.new(@ldap, @config)
     @gfilter = group_filter('group') & group_class_filter
   end
 

--- a/test/ad_test.rb
+++ b/test/ad_test.rb
@@ -4,40 +4,24 @@ class TestAD < MiniTest::Test
   include LdapTestHelper
 
   def setup
-    config
+    super
     @ad   = LdapFluff::ActiveDirectory.new(@config)
-    @ldap = MiniTest::Mock.new
   end
 
   # default setup for service bind users
   def service_bind
-    @ldap.expect(:auth, nil, %w(service@internet.com pass))
-    @ldap.expect(:bind, true)
-    @ad.ldap = @ldap
-  end
-
-  def basic_user
-    @md = MiniTest::Mock.new
-    @md.expect(:find_user_groups, %w(bros), %w(john))
-    @ad.member_service = @md
-  end
-
-  def bigtime_user
-    @md = MiniTest::Mock.new
-    @md.expect(:find_user_groups, %w(bros broskies), %w(john))
-    @ad.member_service = @md
+    @ldap.expect(:auth, nil, %w(service pass))
+    super
   end
 
   def test_good_bind
-    @ldap.expect(:auth, nil, %w(internet@internet.com password))
-    @ldap.expect(:bind, true)
-    @ad.ldap = @ldap
-    assert_equal(@ad.bind?("internet", "password"), true)
+    service_bind
+    assert_equal(@ad.bind?('service', 'pass'), true)
     @ldap.verify
   end
 
   def test_bad_bind
-    @ldap.expect(:auth, nil, %w(internet@internet.com password))
+    @ldap.expect(:auth, nil, %w(internet password))
     @ldap.expect(:bind, false)
     @ad.ldap = @ldap
     assert_equal(@ad.bind?("internet", "password"), false)
@@ -52,20 +36,20 @@ class TestAD < MiniTest::Test
 
   def test_bad_user
     service_bind
-    @md = MiniTest::Mock.new
-    @md.expect(:find_user_groups, nil, %w(john))
-    def @md.find_user_groups(*args)
+    md = MiniTest::Mock.new
+    md.expect(:find_user_groups, nil, %w(john))
+    def md.find_user_groups(*args)
       raise LdapFluff::ActiveDirectory::MemberService::UIDNotFoundException
     end
-    @ad.member_service = @md
+    @ad.member_service = md
     assert_equal(@ad.groups_for_uid('john'), [])
   end
 
   def test_bad_service_user
-    @ldap.expect(:auth, nil, %w(service@internet.com pass))
+    @ldap.expect(:auth, nil, %w(service pass))
     @ldap.expect(:bind, false)
     @ad.ldap = @ldap
-    assert_raises(LdapFluff::ActiveDirectory::UnauthenticatedActiveDirectoryException) do
+    assert_raises(LdapFluff::ActiveDirectory::UnauthenticatedException) do
       @ad.groups_for_uid('john')
     end
   end
@@ -101,41 +85,63 @@ class TestAD < MiniTest::Test
   end
 
   def test_user_exists
-    @md = MiniTest::Mock.new
-    @md.expect(:find_user, 'notnilluser', %w(john))
-    @ad.member_service = @md
+    md = MiniTest::Mock.new
+    md.expect(:find_user, 'notnilluser', %w(john))
+    @ad.member_service = md
     service_bind
     assert(@ad.user_exists?('john'))
   end
 
   def test_missing_user
-    @md = MiniTest::Mock.new
-    @md.expect(:find_user, nil, %w(john))
-    def @md.find_user(uid)
+    md = MiniTest::Mock.new
+    md.expect(:find_user, nil, %w(john))
+    def md.find_user(uid)
       raise LdapFluff::ActiveDirectory::MemberService::UIDNotFoundException
     end
-    @ad.member_service = @md
+    @ad.member_service = md
     service_bind
     refute(@ad.user_exists?('john'))
   end
 
   def test_group_exists
-    @md = MiniTest::Mock.new
-    @md.expect(:find_group, 'notnillgroup', %w(broskies))
-    @ad.member_service = @md
+    md = MiniTest::Mock.new
+    md.expect(:find_group, 'notnillgroup', %w(broskies))
+    @ad.member_service = md
     service_bind
     assert(@ad.group_exists?('broskies'))
   end
 
   def test_missing_group
-    @md = MiniTest::Mock.new
-    @md.expect(:find_group, nil, %w(broskies))
-    def @md.find_group(uid)
+    md = MiniTest::Mock.new
+    md.expect(:find_group, nil, %w(broskies))
+    def md.find_group(uid)
       raise LdapFluff::ActiveDirectory::MemberService::GIDNotFoundException
     end
-    @ad.member_service = @md
+    @ad.member_service = md
     service_bind
     refute(@ad.group_exists?('broskies'))
+  end
+
+  def test_find_users_in_nested_groups
+    group        = Net::LDAP::Entry.new('foremaners')
+    nested_group = Net::LDAP::Entry.new('katellers')
+    nested_user  = Net::LDAP::Entry.new('testuser')
+
+    group[:member]        = ['CN=katellers,DC=corp,DC=windows,DC=com']
+    nested_group[:member] = ['CN=testuser,CN=Users,DC=corp,DC=windows,DC=com']
+    nested_group[:objectclass] = ['organizationalunit']
+    nested_user[:objectclass]  = ['person']
+
+    md = MiniTest::Mock.new
+    2.times { md.expect(:find_group, [group], ['foremaners']) }
+    2.times { md.expect(:find_group, [nested_group], ['katellers']) }
+    2.times { service_bind }
+
+    md.expect(:find_user,  [nested_group], ['katellers'])
+    md.expect(:find_user,  [nested_user],  ['testuser'])
+    md.expect(:get_logins, 'testuser', [nested_group.member])
+    @ad.member_service = md
+    assert_equal @ad.users_for_gid('foremaners'), ['testuser']
   end
 
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -4,7 +4,7 @@ class ConfigTest < MiniTest::Test
   include LdapTestHelper
 
   def test_unsupported_type
-    assert_raises(LdapFluff::ConfigError) { LdapFluff.new(config_hash.update :server_type => 'inactive_directory') }
+    assert_raises(LdapFluff::Config::ConfigError) { LdapFluff.new(config_hash.update :server_type => 'inactive_directory') }
   end
 
   def test_load_posix

--- a/test/ipa_member_services_test.rb
+++ b/test/ipa_member_services_test.rb
@@ -4,9 +4,8 @@ class TestIPAMemberService < MiniTest::Test
   include LdapTestHelper
 
   def setup
-    config
-    @ldap  = MiniTest::Mock.new
-    @ipams = LdapFluff::FreeIPA::MemberService.new(@ldap, @config.group_base)
+    super
+    @ipams = LdapFluff::FreeIPA::MemberService.new(@ldap, @config)
   end
 
   def basic_user

--- a/test/ldap_test.rb
+++ b/test/ldap_test.rb
@@ -4,8 +4,7 @@ class TestLDAP < MiniTest::Test
   include LdapTestHelper
 
   def setup
-    config
-    @ldap  = MiniTest::Mock.new
+    super
     @fluff = LdapFluff.new(config_hash)
   end
 

--- a/test/posix_member_services_test.rb
+++ b/test/posix_member_services_test.rb
@@ -4,15 +4,22 @@ class TestPosixMemberService < MiniTest::Test
   include LdapTestHelper
 
   def setup
-    config
-    @ldap = MiniTest::Mock.new
-    @ms   = LdapFluff::Posix::MemberService.new(@ldap, @config.group_base)
+    super
+    @ms = LdapFluff::Posix::MemberService.new(@ldap, @config)
   end
 
   def test_find_user
     user = posix_user_payload
     @ldap.expect(:search, user, [:filter => @ms.name_filter('john'),
                                  :base   => config.group_base])
+    @ms.ldap = @ldap
+    assert_equal posix_user_payload, @ms.find_user('john')
+    @ldap.verify
+  end
+
+  def test_find_user_groups
+    user = posix_user_payload
+    @ldap.expect(:search, user, [:filter => @ms.name_filter('john')])
     @ms.ldap = @ldap
     assert_equal ['bros'], @ms.find_user_groups('john')
     @ldap.verify


### PR DESCRIPTION
Most logic comes from here: https://github.com/theforeman/foreman/blob/develop/app/models/auth_sources/auth_source_ldap.rb 

and https://github.com/theforeman/foreman/pull/529 , which this PR is meant to facilitate.
