### PR TITLE
Update to work with Rails 4

### DIFF
--- a/ldap_fluff.gemspec
+++ b/ldap_fluff.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ldap_fluff'
-  s.version     = '0.2.6'
+  s.version     = '0.3.0'
   s.summary     = 'LDAP Querying tools for Active Directory, FreeIPA and Posix-style'
   s.description = 'Simple library for binding & group querying on top of various ldap implementations'
   s.homepage    = 'https://github.com/Katello/ldap_fluff'


### PR DESCRIPTION
**Changes Made:**
- This just updates the gem to work with Rails 4. 
- Bump version to 3.0 

**WHY:**
- I created this because the other PR that is up, and works with Rails 4, wasn't actually authenticating passwords. We are using this PR in production and the auth is working. 
