### PR TITLE
Enable service binding for POSIX LDAP servers

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,8 +53,8 @@ Your global configuration must provide information about your LDAP host to funct
   group_base: # base DN for your LDAP groups, eg ou=Groups,dc=redhat,dc=com
   server_type: # type of server. default == posix. :active_directory, :posix, :free_ipa
   ad_domain: # domain for your users if using active directory, eg redhat.com
-  service_user: # service account for authenticating LDAP calls in active directory or freeipa. required unless you enable anon
-  service_pass: # service password for authenticating LDAP calls in active directory or freeipa. required unless you enable anon
+  service_user: # service account for authenticating LDAP calls. required unless you enable anon
+  service_pass: # service password for authenticating LDAP calls. required unless you enable anon
   anon_queries: # false by default, true if you don't want to use the service user
 
 You can pass these arguments as a hash to LdapFluff to get a valid LdapFluff object.

--- a/lib/ldap_fluff/config.rb
+++ b/lib/ldap_fluff/config.rb
@@ -49,7 +49,7 @@ class LdapFluff::Config
     end
 
     %w[service_user service_pass].all? do |key|
-      if !config['anon_queries'] && config['server_type'] != :posix && config[key].nil?
+      if !config['anon_queries'] && config[key].nil?
         raise ConfigError, "config key #{key} has to be set, it was nil"
       end
     end

--- a/test/lib/ldap_test_helper.rb
+++ b/test/lib/ldap_test_helper.rb
@@ -74,6 +74,10 @@ module LdapTestHelper
     "uid=#{uid},cn=users,cn=accounts,#{@config.base_dn}"
   end
 
+  def ad_user_bind(name)
+    "CN=#{name},CN=Users,#{@config.base_dn}"
+  end
+
   def ad_user_payload
     [{ :memberof => ["cn=group,dc=internet,dc=com"] }]
   end


### PR DESCRIPTION
Based on https://github.com/csschwe/ldap_fluff/commit/d0dcb9b3869fa79a702936418d13ce6f43ef0cdd

Now when trying to authenticate/bind with the POSIX type, the service account (if supplied) will be used to look up the UID rather than relying on bind_as, which assumed anonymous access to the LDAP server was possible.  Much of this code has been moved up into the generic implementation as lack of anonymous access isn't a POSIX feature.

The AD/IPA implementations also now look up the UID in similar ways, so logging in as a username works consistently across all three.
