### PR TITLE
Allow use of groupOfUniqueNames with posix provider

### DIFF
--- a/lib/ldap_fluff/generic.rb
+++ b/lib/ldap_fluff/generic.rb
@@ -35,8 +35,8 @@ class LdapFluff::Generic
     return [] unless group_exists?(gid)
     search = @member_service.find_group(gid).last
 
-    method = [:member, :ismemberof,
-              :memberof, :memberuid].find { |m| search.respond_to? m } or
+    method = [:member, :ismemberof, :memberof,
+              :memberuid, :uniquemember].find { |m| search.respond_to? m } or
              raise 'Group does not have any members'
 
     users_from_search_results(search, method)

--- a/lib/ldap_fluff/posix.rb
+++ b/lib/ldap_fluff/posix.rb
@@ -29,7 +29,8 @@ class LdapFluff::Posix < LdapFluff::Generic
 
     groups = @ldap.search(:base   => search.dn,
                           :filter => Net::LDAP::Filter.eq('objectClass','posixGroup') |
-                                     Net::LDAP::Filter.eq('objectClass', 'organizationalunit'))
+                                     Net::LDAP::Filter.eq('objectClass', 'organizationalunit') |
+                                     Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames'))
 
     members = groups.map { |group| group.send(method) }.flatten.uniq
 

--- a/test/posix_test.rb
+++ b/test/posix_test.rb
@@ -97,7 +97,8 @@ class TestPosix < MiniTest::Test
                  [nested_group],
                  [{ :base   => group.dn,
                     :filter => Net::LDAP::Filter.eq('objectClass','posixGroup') |
-                               Net::LDAP::Filter.eq('objectClass', 'organizationalunit')}])
+                               Net::LDAP::Filter.eq('objectClass', 'organizationalunit') |
+                               Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames')}])
     @posix.ldap = @ldap
 
     md = MiniTest::Mock.new


### PR DESCRIPTION
This will allow the posix provider to use a groupOfUniqueNames group in LDAP.  This could also be split into a separate provider if it doesn't make sense for the posix provider to support this group type.
