### PR TITLE
Fix finding members of AD groups

### DIFF
--- a/lib/ldap_fluff/active_directory.rb
+++ b/lib/ldap_fluff/active_directory.rb
@@ -30,15 +30,13 @@ class LdapFluff::ActiveDirectory < LdapFluff::Generic
     users = []
 
     search.send(method).each do |member|
-      cn    = member.downcase.split(',')[0].split('=')[1]
-      entry = @member_service.find_user(cn).first
-
+      entry = @member_service.find_by_dn(member).first
       objectclasses = entry.objectclass.map(&:downcase)
 
       if (%w(organizationalperson person) & objectclasses).present?
-        users << @member_service.get_logins([member])
+        users << @member_service.get_login_from_entry(entry)
       elsif (%w(organizationalunit group) & objectclasses).present?
-        users << users_for_gid(cn)
+        users << users_for_gid(entry.cn.first)
       end
     end
 

--- a/test/ad_test.rb
+++ b/test/ad_test.rb
@@ -154,7 +154,8 @@ class TestAD < MiniTest::Test
     nested_user  = Net::LDAP::Entry.new('testuser')
 
     group[:member]        = ['CN=katellers,DC=corp,DC=windows,DC=com']
-    nested_group[:member] = ['CN=testuser,CN=Users,DC=corp,DC=windows,DC=com']
+    nested_group[:cn]     = ['katellers']
+    nested_group[:member] = ['CN=Test User,CN=Users,DC=corp,DC=windows,DC=com']
     nested_group[:objectclass] = ['organizationalunit']
     nested_user[:objectclass]  = ['person']
 
@@ -163,11 +164,12 @@ class TestAD < MiniTest::Test
     2.times { md.expect(:find_group, [nested_group], ['katellers']) }
     2.times { service_bind }
 
-    md.expect(:find_user,  [nested_group], ['katellers'])
-    md.expect(:find_user,  [nested_user],  ['testuser'])
-    md.expect(:get_logins, 'testuser', [nested_group.member])
+    md.expect(:find_by_dn, [nested_group], ['CN=katellers,DC=corp,DC=windows,DC=com'])
+    md.expect(:find_by_dn, [nested_user],  ['CN=Test User,CN=Users,DC=corp,DC=windows,DC=com'])
+    md.expect(:get_login_from_entry, 'testuser', [nested_user])
     @ad.member_service = md
     assert_equal @ad.users_for_gid('foremaners'), ['testuser']
+    md.verify
   end
 
 end


### PR DESCRIPTION
Previously UIDs weren't being looked up, as AD groups store the DN in the
member attribute of the group, which doesn't contain the login name or
attribute (typically it's the user's CN).  Now a search is done on the DN
and the login attribute returned from the entry.

(It only worked before when the CN equalled the username I think.)
