### PR TITLE
Fixes user group listing for member

### DIFF
--- a/lib/ldap_fluff/freeipa_member_service.rb
+++ b/lib/ldap_fluff/freeipa_member_service.rb
@@ -14,8 +14,9 @@ class LdapFluff::FreeIPA::MemberService < LdapFluff::GenericMemberService
     user = find_user(uid)
     # if group data is missing, they aren't querying with a user
     # with enough privileges
-    raise InsufficientQueryPrivilegesException if user.size <= 1
-    get_groups(user[1][:memberof])
+    user.delete_if { |u| u.nil? || !u.respond_to?(:attribute_names) || !u.attribute_names.include?(:memberof) }
+    raise InsufficientQueryPrivilegesException if user.size < 1
+    get_groups(user[0][:memberof])
   end
 
   class UIDNotFoundException < LdapFluff::Error

--- a/test/ipa_member_services_test.rb
+++ b/test/ipa_member_services_test.rb
@@ -33,7 +33,9 @@ class TestIPAMemberService < MiniTest::Test
   end
 
   def test_no_groups
-    @ldap.expect(:search, ['', { :memberof => [] }], [:filter => ipa_name_filter("john")])
+    entry = Net::LDAP::Entry.new
+    entry['memberof'] = []
+    @ldap.expect(:search, [ Net::LDAP::Entry.new, entry ], [:filter => ipa_name_filter("john")])
     @ipams.ldap = @ldap
     assert_equal([], @ipams.find_user_groups('john'))
     @ldap.verify

--- a/test/lib/ldap_test_helper.rb
+++ b/test/lib/ldap_test_helper.rb
@@ -103,7 +103,13 @@ module LdapTestHelper
   end
 
   def ipa_user_payload
-    [{ :cn => 'john' }, { :memberof => ['cn=group,dc=internet,dc=com', 'cn=bros,dc=internet,dc=com'] }]
+    @ipa_user_payload_cache ||= begin
+      entry_1 = Net::LDAP::Entry.new
+      entry_1['cn'] = 'John'
+      entry_2 = Net::LDAP::Entry.new
+      entry_2['memberof'] = ['cn=group,dc=internet,dc=com', 'cn=bros,dc=internet,dc=com']
+      [ entry_1, entry_2 ]
+    end
   end
 
   def ipa_group_payload


### PR DESCRIPTION
My FreeIPA does not return empty string as a first record. I improved
detection of results so we filter only LDAP records. If we have at least
one records, we can load memberof attribute.
