### PR TITLE
Users for GID returns empty array for empty group

### DIFF
--- a/lib/ldap_fluff/generic.rb
+++ b/lib/ldap_fluff/generic.rb
@@ -44,7 +44,7 @@ class LdapFluff::Generic
 
     method = [:member, :ismemberof, :memberof,
               :memberuid, :uniquemember].find { |m| search.respond_to? m } or
-             raise 'Group does not have any members'
+             return []
 
     users_from_search_results(search, method)
   end


### PR DESCRIPTION
As requested in https://github.com/theforeman/foreman/pull/1744#issuecomment-62115936
