### PR TITLE
Escape commas, slightly differently

### DIFF
--- a/lib/ldap_fluff/generic_member_service.rb
+++ b/lib/ldap_fluff/generic_member_service.rb
@@ -22,8 +22,9 @@ class LdapFluff::GenericMemberService
   end
 
   def find_by_dn(dn)
-    entry, base = dn.split(',', 2)
+    entry, base = dn.split(/(?<!\\),/, 2)
     entry_attr, entry_value = entry.split('=', 2)
+    entry_value = entry_value.gsub('\,', ',')
     user = @ldap.search(:filter => name_filter(entry_value, entry_attr), :base => base)
     raise self.class::UIDNotFoundException if (user.nil? || user.empty?)
     user

--- a/test/ad_member_services_test.rb
+++ b/test/ad_member_services_test.rb
@@ -120,6 +120,17 @@ class TestADMemberService < MiniTest::Test
     @ldap.verify
   end
 
+  def test_find_by_dn_comma_in_cn
+    # In at least one AD installation, users who have commas in their CNs are
+    # returned by the server in answer to a group membership query with
+    # backslashes before the commas in the CNs. Such escaped commas should not
+    # be used when splitting the DN.
+    @ldap.expect(:search, [:result], [:filter => Net::LDAP::Filter.eq('cn', 'Bar, Foo'), :base => 'dc=example,dc=com'])
+    @adms.ldap = @ldap
+    assert_equal([:result], @adms.find_by_dn('cn=Bar\, Foo,dc=example,dc=com'))
+    @ldap.verify
+  end
+
   def test_find_by_dn_missing_entry
     @ldap.expect(:search, nil, [:filter => Net::LDAP::Filter.eq('cn', 'Foo Bar'), :base => 'dc=example,dc=com'])
     @adms.ldap = @ldap


### PR DESCRIPTION
This is a slightly different way from #38 to deal with escaped commas in Active Directory DNs, with tests added.