### PR TITLE
Remove Ruby 1.8.7 support, 1.9.3+ now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - '1.8.7'
   - '1.9.3'
   - '2.0.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'rubocop' if RUBY_VERSION !~ /1\.8\.7/

--- a/ldap_fluff.gemspec
+++ b/ldap_fluff.gemspec
@@ -15,14 +15,11 @@ Gem::Specification.new do |s|
   s.author   = ['Jordan O\'Mara', 'Daniel Lobato', 'Petr Chalupa', 'Adam Price', 'Marek Hulan']
   s.email    = %w(jomara@redhat.com elobatocs@gmail.com pchalupa@redhat.com komidore64@gmail.com mhulan@redhat.com)
 
-  if RUBY_VERSION < '1.9'
-    s.add_dependency('net-ldap', '>= 0.3.1', '< 0.9.0')
-    s.add_dependency('activesupport', '~> 3.2')
-    s.add_dependency('i18n', '< 0.7.0')
-  else
-    s.add_dependency('net-ldap', '>= 0.3.1')
-    s.add_dependency('activesupport')
-  end
+  s.required_ruby_version = ">= 1.9.3"
+
+  s.add_dependency('net-ldap', '>= 0.3.1')
+  s.add_dependency('activesupport')
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest')
+  s.add_development_dependency('rubocop')
 end


### PR DESCRIPTION
Foreman doesn't use the 1.8.7 support, and dropping it will allow for
merging of a 1.9+ specific fix for escaped commas in UIDs.

---

Checking that Travis is green with this still.  We can release it as a 0.4.0 I guess.