### PR TITLE
Remove memberof attributes from group's UID listing

### DIFF
--- a/lib/ldap_fluff/generic.rb
+++ b/lib/ldap_fluff/generic.rb
@@ -43,8 +43,7 @@ class LdapFluff::Generic
     return [] unless group_exists?(gid)
     search = @member_service.find_group(gid).last
 
-    method = [:member, :ismemberof, :memberof,
-              :memberuid, :uniquemember].find { |m| search.respond_to? m } or
+    method = [:member, :memberuid, :uniquemember].find { |m| search.respond_to? m } or
              return []
 
     users_from_search_results(search, method)


### PR DESCRIPTION
When retrieving users_for_gid for an AD group that contains another,
empty group as a member, this prevents an infinite recursion.

Previously users_for_gid would be called against the empty group.  Since
it had no members, `search.respond_to?(:member)` was false and the
method returned the result of `search.memberof`.  This caused the member
lookup to check the outer group again, resulting in an infinite loop.