### PR TITLE
POSIX group_list(login) uses group base DN

### DIFF
--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -8,8 +8,8 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
     super
   end
 
-  def find_user(uid)
-    user = @ldap.search(:filter => name_filter(uid), :base => @base)
+  def find_user(uid, base_dn = @base)
+    user = @ldap.search(:filter => name_filter(uid), :base => base_dn)
     raise UIDNotFoundException if (user.nil? || user.empty?)
     user
   end
@@ -18,7 +18,8 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   # note : this method is not particularly fast for large ldap systems
   def find_user_groups(uid)
     groups = []
-    @ldap.search(:filter => Net::LDAP::Filter.eq('memberuid', uid)).each do |entry|
+    @ldap.search(:filter => Net::LDAP::Filter.eq('memberuid', uid),
+                 :base => @group_base).each do |entry|
       groups << entry[:cn][0]
     end
     groups

--- a/test/posix_member_services_test.rb
+++ b/test/posix_member_services_test.rb
@@ -19,7 +19,8 @@ class TestPosixMemberService < MiniTest::Test
 
   def test_find_user_groups
     user = posix_user_payload
-    @ldap.expect(:search, user, [:filter => @ms.name_filter('john')])
+    @ldap.expect(:search, user, [:filter => @ms.name_filter('john'),
+                                 :base => config.group_base])
     @ms.ldap = @ldap
     assert_equal ['bros'], @ms.find_user_groups('john')
     @ldap.verify


### PR DESCRIPTION
This commit changes the underlying methods for group_list so
that they start using the group base DN to search for groups,
as it was using the global DN before.

Just so I remember this is for https://bugzilla.redhat.com/show_bug.cgi?id=1387383