### PR TITLE
Ignore groups when parsing users in AD

### DIFF
--- a/lib/ldap_fluff/active_directory.rb
+++ b/lib/ldap_fluff/active_directory.rb
@@ -30,7 +30,11 @@ class LdapFluff::ActiveDirectory < LdapFluff::Generic
     users = []
 
     search.send(method).each do |member|
-      entry = @member_service.find_by_dn(member).first
+      begin
+        entry = @member_service.find_by_dn(member).first
+      rescue MemberService::UIDNotFoundException
+        next
+      end
       objectclasses = entry.objectclass.map(&:downcase)
 
       if (%w(organizationalperson person userproxy) & objectclasses).present?

--- a/test/ad_test.rb
+++ b/test/ad_test.rb
@@ -110,6 +110,19 @@ class TestAD < MiniTest::Test
     assert_equal(@ad.is_in_groups("john", %w(broskies), true), true)
   end
 
+  def test_subgroups_in_groups_are_ignored
+    group        = Net::LDAP::Entry.new('foremaners')
+    md = MiniTest::Mock.new
+    2.times { md.expect(:find_group, [group], ['foremaners']) }
+    2.times { service_bind }
+    def md.find_by_dn(dn)
+      raise LdapFluff::ActiveDirectory::MemberService::UIDNotFoundException
+    end
+    @ad.member_service = md
+    assert_equal @ad.users_for_gid('foremaners'), []
+    md.verify
+  end
+
   def test_user_exists
     md = MiniTest::Mock.new
     md.expect(:find_user, 'notnilluser', %w(john))


### PR DESCRIPTION
Listing the users in a group in AD can fail if the group in AD contains
also DNs that correspond to a group, not a user.

This commit fixes that by ignoring DNs that cannot be found using the
UID.