### PR TITLE
Fixes #18887 - defensive group search in posix_member_service

### DIFF
--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -17,9 +17,11 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   # return an ldap user with groups attached
   # note : this method is not particularly fast for large ldap systems
   def find_user_groups(uid)
-    groups = []
-    @ldap.search(:filter => Net::LDAP::Filter.eq('memberuid', uid), :base => @group_base).each do |entry|
-      groups << entry[:cn][0]
+    group_search = @ldap.search(:filter => Net::LDAP::Filter.eq('memberuid', uid), :base => @group_base)
+    if group_search
+      group_search.each do |entry|
+        groups << entry[:cn][0]
+      end
     end
     groups
   end


### PR DESCRIPTION
The posix_member_service was not counting on issues with missing
group base_dn, leading to "undefined method `each' for nil:NilClass"
error during LDAP login and group search