### PR TITLE
Enable Active Directory primary groups

### DIFF
--- a/lib/ldap_fluff/active_directory.rb
+++ b/lib/ldap_fluff/active_directory.rb
@@ -44,6 +44,13 @@ class LdapFluff::ActiveDirectory < LdapFluff::Generic
       end
     end
 
+    # In AD, the relationship between a user account and the "Primary Group" for that account
+    #    is not included in the member and memberof attributes.
+    if search.respond_to? 'primarygrouptoken'
+      primary_users = @ldap.search(:base => @ldap.base, :filter => Net::LDAP::Filter.eq('primarygroupid',search['primarygrouptoken'].first))
+      users += primary_users.map { |user| @member_service.get_login_from_entry(user) }
+    end
+
     users.flatten.uniq
   end
 

--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -8,6 +8,12 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
     super
   end
 
+  def find_group(gid)
+    group = @ldap.search(:filter => group_filter(gid), :base => @group_base, :attributes => ['*','primaryGroupToken'])
+    raise self.class::GIDNotFoundException if (group.nil? || group.empty?)
+    group
+  end
+
   # get a list [] of ldap groups for a given user
   # in active directory, this means a recursive lookup
   def find_user_groups(uid)
@@ -19,9 +25,20 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
   def _groups_from_ldap_data(payload)
     data = []
     if !payload.nil?
-      first_level     = payload[:memberof]
-      total_groups, _ = _walk_group_ancestry(first_level, first_level)
-      data            = (get_groups(first_level + total_groups)).uniq
+      first_level         = payload[:memberof]
+      normal_groups, _    = _walk_group_ancestry(first_level, first_level)
+      # In AD, a user's primary group is not included in the memberOf list, and must be handled separately.
+      #   By default, a new user's primary group is 'Domain Users'
+      primary_groups      = []
+      primary_first_level = []
+      if !payload[:primarygroupid].nil?
+        domain_sid          = _get_sid_string(payload[:objectsid].first).split('-')[0..-2].join('-')
+        primary_sid         = domain_sid + '-' + payload[:primarygroupid].first
+        primary_group       = @ldap.search(:filter => Net::LDAP::Filter.eq('objectsid', primary_sid), :base => @group_base, :attributes => ['memberof']).first
+        primary_first_level = primary_group[:dn]
+        primary_groups, _   = _walk_group_ancestry(primary_first_level, primary_first_level)
+      end
+      data              = (get_groups(first_level + normal_groups + primary_first_level + primary_groups)).uniq
     end
     data
   end
@@ -41,6 +58,23 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
       end
     end
     [set, known_groups]
+  end
+
+  def _get_sid_string(sid_bin)
+    sid = []
+ 
+    # Byte 1: SID structure revision number (always 1 so far...)
+    sid << sid_bin[0].unpack("H2").first.to_i
+ 
+    # Skip byte 2
+    # Bytes 3-8: Identifier Authority
+    sid << sid_bin[2,6].unpack("H*").first.to_i
+
+    # Remaining bytes: list of unsigned, 32-bit, little-endian ints
+    sid += sid_bin.unpack("@8V*")
+
+    # Put it all together.
+    "S-" + sid.join('-')
   end
 
   def class_filter


### PR DESCRIPTION
Include primary group relationships when searching groups by users, or users by group.  Active Directory does not include this relationship in the member and memberOf collections in LDAP queries.