### PR TITLE
Remove deprecated LdapError usage

### DIFF
--- a/ldap_fluff.gemspec
+++ b/ldap_fluff.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.4.0"
 
-  s.add_dependency('net-ldap', '>= 0.3.1')
+  s.add_dependency('net-ldap', '>= 0.11')
   s.add_dependency('activesupport')
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest')

--- a/lib/ldap_fluff/generic_member_service.rb
+++ b/lib/ldap_fluff/generic_member_service.rb
@@ -11,7 +11,7 @@ class LdapFluff::GenericMemberService
     @search_filter = nil
     begin
       @search_filter = Net::LDAP::Filter.construct(config.search_filter) unless (config.search_filter.nil? || config.search_filter.empty?)
-    rescue Net::LDAP::LdapError => error
+    rescue Net::LDAP::Error => error
       puts "Search filter unavailable - #{error}"
     end
   end


### PR DESCRIPTION
Net::LDAP::LdapError has been deprecated since https://github.com/ruby-ldap/ruby-net-ldap/commit/c9d36cdf919e01996da5c61838c10c1bc59f3e81#diff-8e534ef69e7fb9fbb691ec029ba3883243f8ffec6c89f9fadfa13a73d5b737fb.
In https://github.com/ruby-ldap/ruby-net-ldap/commit/94b9d4d0443b8be37b91fcb5d6a31a9589cca41a#diff-8e534ef69e7fb9fbb691ec029ba3883243f8ffec6c89f9fadfa13a73d5b737fb it has got removed, so it will not be around once we upgrade to new version of `net-ldap`.