### PR TITLE
Use msds-memberOfTransitive when possible for AD group lookups

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -83,6 +83,8 @@ ldap_fluff does not support searching/binding global catalogs
 
 service_user (formatted as "ad_domain/username") and service_pass OR anon_queries are required for AD support
 
+Group membership searches will use "msds-memberOfTransitive" where possible, and will fall back to a recursive lookup
+
 === A note on FreeIPA
 
 ldap_fluff appends cn=groups,cn=accounts to the beginning of all BIND calls. You do not need to

--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -26,14 +26,16 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
 
   # return the domain functionality level, default to 0
   def _get_domain_func_level
-    domain_functionality = 0
+    return @domain_functionality unless @domain_functionality.nil?
+
+    @domain_functionality = 0
 
     search = @ldap.search(:base => "", :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['domainFunctionality'])
     if !search.nil? && !search.first.nil?
-      domain_functionality = search.first[:domainfunctionality].first.to_i
+      @domain_functionality = search.first[:domainfunctionality].first.to_i
     end
 
-    domain_functionality
+    @domain_functionality
   end
 
   # return the :memberof attrs + parents, recursively

--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -11,14 +11,8 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
   # try to use msds-memberOfTransitive if it is supported, otherwise do a recursive loop
   def find_user_groups(uid)
     user_data = find_user(uid).first
-    domain_functionality = 0
 
-    search = @ldap.search(:base => "", :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['domainFunctionality'])
-    if !search.nil? && !search.first.nil?
-      domain_functionality = search.first['domainfunctionality'].first.to_i
-    end
-
-    if domain_functionality >= 6
+    if _get_domain_func_level >= 6
       user_dn = user_data[:distinguishedname].first
       search = @ldap.search(:base => user_dn, :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['msds-memberOfTransitive'])
       if !search.nil? && !search.first.nil?
@@ -28,6 +22,18 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
 
     # Fall back to recursive lookup
     _groups_from_ldap_data(user_data)
+  end
+
+  # return the domain functionality level, default to 0
+  def _get_domain_func_level
+    domain_functionality = 0
+
+    search = @ldap.search(:base => "", :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['domainFunctionality'])
+    if !search.nil? && !search.first.nil?
+      domain_functionality = search.first['domainfunctionality'].first.to_i
+    end
+
+    domain_functionality
   end
 
   # return the :memberof attrs + parents, recursively

--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -30,7 +30,7 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
 
     search = @ldap.search(:base => "", :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['domainFunctionality'])
     if !search.nil? && !search.first.nil?
-      domain_functionality = search.first['domainfunctionality'].first.to_i
+      domain_functionality = search.first[:domainfunctionality].first.to_i
     end
 
     domain_functionality

--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -11,29 +11,23 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
   # try to use msds-memberOfTransitive if it is supported, otherwise do a recursive loop
   def find_user_groups(uid)
     user_data = find_user(uid).first
+    domain_functionality = 0
 
-    begin
-      search = @ldap.search(:base => "", :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['domainFunctionality'])
-      if !search.nil? && !search.first.nil?
-        domainFunctionality = search.first['domainfunctionality'].first
-        if domainFunctionality.to_i >= 6
-          user_dn = user_data[:distinguishedname].first
-          search = @ldap.search(:base => user_dn, :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['msds-memberOfTransitive'])
-          if !search.nil? && !search.first.nil?
-            get_groups(search.first['msds-memberoftransitive'])
-          else
-            raise "Transitive query failed"
-          end
-        else
-          raise "Transitive properties not supported"
-        end
-      else
-        raise "Domain functionality query failed"
-      end
-    rescue
-      # If any exceptions are raised, fall back to recursive lookup
-      _groups_from_ldap_data(user_data)
+    search = @ldap.search(:base => "", :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['domainFunctionality'])
+    if !search.nil? && !search.first.nil?
+      domain_functionality = search.first['domainfunctionality'].first.to_i
     end
+
+    if domain_functionality >= 6
+      user_dn = user_data[:distinguishedname].first
+      search = @ldap.search(:base => user_dn, :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['msds-memberOfTransitive'])
+      if !search.nil? && !search.first.nil?
+        return get_groups(search.first['msds-memberoftransitive'])
+      end
+    end
+
+    # Fall back to recursive lookup
+    _groups_from_ldap_data(user_data)
   end
 
   # return the :memberof attrs + parents, recursively

--- a/test/ad_member_services_test.rb
+++ b/test/ad_member_services_test.rb
@@ -10,7 +10,7 @@ class TestADMemberService < MiniTest::Test
   end
 
   def basic_user
-    @ldap.expect(:search, ad_user_payload("john"), [:filter => ad_name_filter("john")])
+    @ldap.expect(:search, ad_user_payload, [:filter => ad_name_filter("john")])
     @ldap.expect(:search, [{ :domainfunctionality => ['5'] }], [:base => "", :scope => 0, :attributes => ['domainFunctionality']])
     @ldap.expect(:search, ad_parent_payload(1), [:base => ad_group_dn, :scope => 0, :attributes => ['memberof']])
   end
@@ -60,7 +60,7 @@ class TestADMemberService < MiniTest::Test
     basic_user
     # basic user is memberof 'group'... and 'group' is memberof 'bros1'
     # now make 'bros1' be memberof 'group' again
-    @ldap.expect(:search, ad_user_payload('john'), [:base => ad_group_dn('bros1'), :scope => 0, :attributes => ['memberof']])
+    @ldap.expect(:search, ad_user_payload, [:base => ad_group_dn('bros1'), :scope => 0, :attributes => ['memberof']])
     @adms.ldap = @ldap
     assert_equal(%w[group bros1], @adms.find_user_groups("john"))
     @ldap.verify
@@ -114,7 +114,7 @@ class TestADMemberService < MiniTest::Test
   def test_find_good_user
     basic_user
     @adms.ldap = @ldap
-    assert_equal(ad_user_payload('john'), @adms.find_user('john'))
+    assert_equal(ad_user_payload, @adms.find_user('john'))
   end
 
   def test_find_missing_user

--- a/test/lib/ldap_test_helper.rb
+++ b/test/lib/ldap_test_helper.rb
@@ -85,8 +85,12 @@ module LdapTestHelper
     "cn=#{name},#{@config.group_base}"
   end
 
-  def ad_user_payload(name)
-    [{ :memberof => [ad_group_dn], :distinguishedname => [ad_user_dn(name)] }]
+  def ad_user_payload(name = nil)
+    unless name.nil?
+      return [{ :memberof => [ad_group_dn], :distinguishedname => [ad_user_dn(name)] }]
+    end
+
+    [{ :memberof => [ad_group_dn] }]
   end
 
   def ad_group_payload

--- a/test/lib/ldap_test_helper.rb
+++ b/test/lib/ldap_test_helper.rb
@@ -85,8 +85,8 @@ module LdapTestHelper
     "cn=#{name},#{@config.group_base}"
   end
 
-  def ad_user_payload
-    [{ :memberof => [ad_group_dn] }]
+  def ad_user_payload(name)
+    [{ :memberof => [ad_group_dn], :distinguishedname => [ad_user_dn(name)] }]
   end
 
   def ad_group_payload


### PR DESCRIPTION
This PR makes use of the `msds-memberOfTransitive` computed property for AD group lookups when possible, instead of the recursive group lookups using `memberOf`. It still falls back to recursive lookups if the transitive property is not available, or if anything fails while attempting to use the transitive property. Therefore it should be backwards compatible with older domains. 

The [msds-memberOfTransitive](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adls/dcddfdd8-5c70-45b7-bc64-a714ed2ca621) property was added in Microsoft Server 2019 R2. We can check the [domainFunctionality](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6dd88965-8feb-4369-ae7e-075985da8071) property to check if the value is greater than or equal to 6 (`DS_BEHAVIOR_WIN2012R2`). 

I've tested this on my own Foreman server, and it works well. Tests should also be passing. 

Fixes #68 