### PR TITLE
Fixes #36306 - Fixing the UserGroup issue when working with RHDS/POSIX

### DIFF
--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -18,10 +18,12 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   def find_user_groups(uid)
     groups = []
     @ldap.search(
-      :filter => Net::LDAP::Filter.eq('memberuid', uid),
+      :filter => Net::LDAP::Filter.eq(@attr_login, uid),
       :base => @group_base, :attributes => ["cn"]
     ).each do |entry|
-      groups << entry[:cn][0]
+      entry[:memberof].each do |grp|
+        groups << grp.sub(/.*?cn=(.*?),.*/, '\1')
+      end
     end
     groups
   end


### PR DESCRIPTION
When working with RHDS (RH Directory Server), the UserGroup feature it's not working properly, the `group_list` method doesn't return the correct group information, even when the plugin `memberof` it's already available.

With this change, it will check the also the `@attr_login` attribute and will use it, once there is no value, then we will assume `memberuid`. Before it was hardcoded to `memberuid`.

Thank you!
Waldirio