### PR TITLE
Raise minimum Ruby version to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_gem:
     - rules/performance.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: '2.7'
   Exclude:
     - 'test/**/*'
     - 'vendor/bundle/**/*'
@@ -21,3 +21,6 @@ Layout:
 
 Style:
   Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: true

--- a/ldap_fluff.gemspec
+++ b/ldap_fluff.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.email    = %w[jomara@redhat.com elobatocs@gmail.com pchalupa@redhat.com
                   komidore64@gmail.com mhulan@redhat.com dominic@cleal.org]
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.7', '< 4'
 
   s.add_dependency('activesupport')
   s.add_dependency('net-ldap', '>= 0.11')


### PR DESCRIPTION
This contain changes of ruby version support, for `>= 2.7', '< 4` 