### PR TITLE
Drop unused methods from PosixMemberService

### DIFF
--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -26,7 +26,7 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
 
   # return the domain functionality level, default to 0
   def _get_domain_func_level
-    return @domain_functionality unless @domain_functionality.nil?
+    return @domain_functionality if defined?(@domain_functionality)
 
     @domain_functionality = 0
 

--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -57,7 +57,7 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
       next unless !search.nil? && !search.first.nil?
       groups = search.first[:memberof] - known_groups
       known_groups                += groups
-      next_level, new_known_groups = _walk_group_ancestry(groups, known_groups)
+      next_level, _new_known_groups = _walk_group_ancestry(groups, known_groups)
       set                         += next_level
       set                         += groups
       known_groups                += next_level

--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -26,27 +26,6 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
     groups
   end
 
-  def times_in_groups(uid, gids, all)
-    filters = []
-    gids.each do |cn|
-      filters << group_filter(cn)
-    end
-    group_filters = merge_filters(filters, all)
-    filter        = name_filter(uid) & group_filters
-    @ldap.search(:base => @group_base, :filter => filter).size
-  end
-
-  # AND or OR all of the filters together
-  def merge_filters(filters = [], all = false)
-    if !filters.nil? && filters.size >= 1
-      filter = filters[0]
-      filters[1..(filters.size - 1)].each do |gfilter|
-        filter = (all ? filter & gfilter : filter | gfilter)
-      end
-      filter
-    end
-  end
-
   class UIDNotFoundException < LdapFluff::Error
   end
 

--- a/test/posix_test.rb
+++ b/test/posix_test.rb
@@ -19,7 +19,8 @@ class TestPosix < Minitest::Test
     assert_equal(@posix.groups_for_uid("john"), %w[bros])
   end
 
-  def test_missing_user
+  def test_groups_missing_user
+    service_bind
     md = Minitest::Mock.new
     md.expect(:find_user_groups, [], %w[john])
     @posix.member_service = md


### PR DESCRIPTION
times_in_groups should be unused since baf56b9
merge_filters seems to be used only in times_in_groups