### PR TITLE
Use map to transform values in find_user_groups

### DIFF
--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -16,14 +16,10 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   # return an ldap user with groups attached
   # note : this method is not particularly fast for large ldap systems
   def find_user_groups(uid)
-    groups = []
     @ldap.search(
       :filter => Net::LDAP::Filter.eq('memberuid', uid),
       :base => @group_base, :attributes => ["cn"]
-    ).each do |entry|
-      groups << entry[:cn][0]
-    end
-    groups
+    ).map { |entry| entry[:cn][0] }
   end
 
   class UIDNotFoundException < LdapFluff::Error


### PR DESCRIPTION
This simplifies the code by using more a expressive method, removing the need for helper variables.