### PR TITLE
Allow activesupport 7.0 usage

### DIFF
--- a/ldap_fluff.gemspec
+++ b/ldap_fluff.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7', '< 4'
 
-  s.add_dependency('activesupport', '>= 5', '< 7.1')
+  s.add_dependency('activesupport', '>= 5', '< 8')
   s.add_dependency('net-ldap', '>= 0.11', '< 1')
   s.add_development_dependency('minitest', '~> 5.0')
   s.add_development_dependency('rake', '~> 13.1')

--- a/ldap_fluff.gemspec
+++ b/ldap_fluff.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7', '< 4'
 
-  s.add_dependency('activesupport', '>= 5', '< 7')
+  s.add_dependency('activesupport', '>= 5', '< 7.1')
   s.add_dependency('net-ldap', '>= 0.11', '< 1')
   s.add_development_dependency('minitest', '~> 5.0')
   s.add_development_dependency('rake', '~> 13.1')


### PR DESCRIPTION
Hard version lock on activesupport being < 7 prevents us to upgrade Rails in Foreman. I suggest to pin it to `7.1` at least to unblock Rails 7.0 upgrade.