### PR TITLE
RFC4519 group membership for posix server type

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,6 +53,8 @@ Your global configuration must provide information about your LDAP host to funct
   group_base: # base DN for your LDAP groups, eg ou=Groups,dc=redhat,dc=com
   use_netgroups: # false by default, use true if you want to use netgroup triples,
                  # supported only for server type :free_ipa and :posix
+  use_rfc4519_group_membership: # false by default, use true if you want to use group membership extensions from RFC4519. Typically you may want to use this if your LDAP server is based on 389DS.
+                                # supported only for server type :posix
   server_type: # type of server. default == :posix. :active_directory, :posix, :free_ipa
   ad_domain: # domain for your users if using active directory, eg redhat.com
   service_user: # service account for authenticating LDAP calls. required unless you enable anon

--- a/lib/ldap_fluff/config.rb
+++ b/lib/ldap_fluff/config.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/hash'
 class LdapFluff::Config
   ATTRIBUTES = %w[host port encryption base_dn group_base server_type service_user
                   service_pass anon_queries attr_login search_filter
-                  instrumentation_service use_netgroups].freeze
+                  instrumentation_service use_netgroups use_rfc4519_group_membership].freeze
   ATTRIBUTES.each { |attr| attr_reader attr.to_sym }
 
   DEFAULT_CONFIG = { 'port' => 389,
@@ -14,7 +14,8 @@ class LdapFluff::Config
                      'server_type' => :free_ipa,
                      'anon_queries' => false,
                      'instrumentation_service' => nil,
-                     'use_netgroups' => false }.freeze
+                     'use_netgroups' => false,
+                     'use_rfc4519_group_membership' => false }.freeze
 
   def initialize(config)
     raise ArgumentError unless config.respond_to?(:to_hash)

--- a/lib/ldap_fluff/generic.rb
+++ b/lib/ldap_fluff/generic.rb
@@ -14,6 +14,7 @@ class LdapFluff::Generic
     @base       = config.base_dn
     @group_base = (config.group_base.empty? ? config.base_dn : config.group_base)
     @use_netgroups = config.use_netgroups
+    @use_rfc4519_group_membership = config.use_rfc4519_group_membership
     @member_service = create_member_service(config)
   end
 

--- a/lib/ldap_fluff/posix.rb
+++ b/lib/ldap_fluff/posix.rb
@@ -19,10 +19,13 @@ class LdapFluff::Posix < LdapFluff::Generic
     filter = if @use_netgroups
                Net::LDAP::Filter.eq('objectClass', 'nisNetgroup')
              else
-               Net::LDAP::Filter.eq('objectClass', 'posixGroup') |
-                 Net::LDAP::Filter.eq('objectClass', 'organizationalunit') |
-                 Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames') |
-                 Net::LDAP::Filter.eq('objectClass', 'groupOfNames')
+               filter = Net::LDAP::Filter.eq('objectClass', 'posixGroup')
+               if @use_rfc4519_group_membership
+                 filter = filter |
+                          Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames') |
+                          Net::LDAP::Filter.eq('objectClass', 'groupOfNames')
+               end
+               filter
              end
     groups = @ldap.search(:base => search.dn, :filter => filter)
     members = groups.map { |group| group.send(method) }.flatten.uniq

--- a/lib/ldap_fluff/posix.rb
+++ b/lib/ldap_fluff/posix.rb
@@ -19,7 +19,8 @@ class LdapFluff::Posix < LdapFluff::Generic
     filter = if @use_netgroups
                Net::LDAP::Filter.eq('objectClass', 'nisNetgroup')
              else
-               filter = Net::LDAP::Filter.eq('objectClass', 'posixGroup')
+               filter = Net::LDAP::Filter.eq('objectClass', 'posixGroup') |
+                        Net::LDAP::Filter.eq('objectClass', 'organizationalunit')
                if @use_rfc4519_group_membership
                  filter = filter |
                           Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames') |

--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -16,8 +16,9 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   # return an ldap user with groups attached
   # note : this method is not particularly fast for large ldap systems
   def find_user_groups(uid)
+    user = find_user(uid).first
     @ldap.search(
-      :filter => user_group_filter(uid),
+      :filter => user_group_filter(uid, user[:dn].first),
       :base => @group_base, :attributes => ["cn"]
     ).map { |entry| entry[:cn][0] }
   end
@@ -30,8 +31,8 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
 
   private
 
-  def user_group_filter(uid)
-    unique_filter = Net::LDAP::Filter.eq('uniquemember', "uid=#{uid},#{@base}") &
+  def user_group_filter(uid, user_dn)
+    unique_filter = Net::LDAP::Filter.eq('uniquemember', user_dn) &
                     Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames')
     Net::LDAP::Filter.eq('memberuid', uid) | unique_filter
   end

--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -17,7 +17,7 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   # note : this method is not particularly fast for large ldap systems
   def find_user_groups(uid)
     @ldap.search(
-      :filter => Net::LDAP::Filter.eq('memberuid', uid),
+      :filter => user_group_filter(uid),
       :base => @group_base, :attributes => ["cn"]
     ).map { |entry| entry[:cn][0] }
   end
@@ -26,5 +26,13 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   end
 
   class GIDNotFoundException < LdapFluff::Error
+  end
+
+  private
+
+  def user_group_filter(uid)
+    unique_filter = Net::LDAP::Filter.eq('uniquemember', "uid=#{uid},#{@base}") &
+                    Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames')
+    Net::LDAP::Filter.eq('memberuid', uid) | unique_filter
   end
 end

--- a/test/lib/ldap_test_helper.rb
+++ b/test/lib/ldap_test_helper.rb
@@ -121,7 +121,7 @@ module LdapTestHelper
   end
 
   def posix_user_payload
-    [{ :cn => ["john"] }]
+    [{ :cn => ["john"], :dn => ["cn=john,ou=people,dc=internet,dc=com"] }]
   end
 
   def posix_group_payload

--- a/test/netiq_test.rb
+++ b/test/netiq_test.rb
@@ -128,9 +128,7 @@ class TestNetIQ < Minitest::Test
       [nested_group],
       [{ :base => group.dn,
          :filter => Net::LDAP::Filter.eq('objectClass', 'posixGroup') |
-                    Net::LDAP::Filter.eq('objectClass', 'organizationalunit') |
-                    Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames') |
-                    Net::LDAP::Filter.eq('objectClass', 'groupOfNames') }])
+                    Net::LDAP::Filter.eq('objectClass', 'organizationalunit') }])
     @netiq.ldap = @ldap
 
     md = Minitest::Mock.new

--- a/test/posix_member_services_test.rb
+++ b/test/posix_member_services_test.rb
@@ -24,7 +24,29 @@ class TestPosixMemberService < Minitest::Test
 
     @ldap.expect(:search, user, [:filter => @ms.name_filter(username),
                                  :base => config.base_dn])
-    filter = @ms.send(:user_group_filter, username, user.first[:dn].first)
+    filter = Net::LDAP::Filter.eq('memberuid', username)
+    @ldap.expect(:search, group, [:filter => filter,
+                                 :base => config.group_base,
+                                 :attributes => ["cn"]])
+    @ms.ldap = @ldap
+    assert_equal ['broze'], @ms.find_user_groups(username)
+    @ldap.verify
+  end
+
+  def test_find_user_groups_rfc4519
+    @ms.instance_variable_set('@use_rfc4519_group_membership', true)
+
+    group = posix_group_payload
+    user = posix_user_payload
+    username = 'john'
+
+    @ldap.expect(:search, user, [:filter => @ms.name_filter(username),
+                                 :base => config.base_dn])
+    filter = [Net::LDAP::Filter.eq('memberuid', username),
+              Net::LDAP::Filter.eq('member', user.first[:dn].first) & Net::LDAP::Filter.eq('objectClass', 'groupOfNames'),
+              Net::LDAP::Filter.eq('uniquemember', user.first[:dn].first) & Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames')
+             ].reduce(&:|)
+
     @ldap.expect(:search, group, [:filter => filter,
                                  :base => config.group_base,
                                  :attributes => ["cn"]])

--- a/test/posix_test.rb
+++ b/test/posix_test.rb
@@ -123,9 +123,7 @@ class TestPosix < Minitest::Test
       [nested_group],
       [{ :base => group.dn,
          :filter => Net::LDAP::Filter.eq('objectClass', 'posixGroup') |
-                    Net::LDAP::Filter.eq('objectClass', 'organizationalunit') |
-                    Net::LDAP::Filter.eq('objectClass', 'groupOfUniqueNames') |
-                    Net::LDAP::Filter.eq('objectClass', 'groupOfNames')}])
+                    Net::LDAP::Filter.eq('objectClass', 'organizationalunit') }])
     @posix.ldap = @ldap
 
     md = Minitest::Mock.new


### PR DESCRIPTION
Builds on top of previous attempts such as https://github.com/theforeman/ldap_fluff/pull/72 and https://github.com/theforeman/ldap_fluff/pull/78 .

This flag only affects posix servers. Without it, user's groups are looked up using the memberuid attribute per RFC2307. POSIX LDAP servers (DS389, FreeIPA when you treat it as a posix server) may support an alternative way of modelling group membership using groupOfNames - member and groupOfUniqueNames - uniqueMember attributes as described in RFC4519.

TODO:
- [x] fix tests