### PR TITLE
Handle search returning nil in searching for POSIX group members

### DIFF
--- a/lib/ldap_fluff/ad_member_service.rb
+++ b/lib/ldap_fluff/ad_member_service.rb
@@ -15,7 +15,9 @@ class LdapFluff::ActiveDirectory::MemberService < LdapFluff::GenericMemberServic
     if _get_domain_func_level >= 6
       user_dn = user_data[:distinguishedname].first
       search = @ldap.search(:base => user_dn, :scope => Net::LDAP::SearchScope_BaseObject, :attributes => ['msds-memberOfTransitive'])
-      if !search.nil? && !search.first.nil?
+      if search.nil?
+        raise Net::LDAP::Error, @ldap.get_operation_result[:error_message].to_s
+      elsif !search.first.nil?
         return get_groups(search.first['msds-memberoftransitive'])
       end
     end

--- a/lib/ldap_fluff/freeipa_netgroup_member_service.rb
+++ b/lib/ldap_fluff/freeipa_netgroup_member_service.rb
@@ -3,9 +3,12 @@ require 'net/ldap'
 class LdapFluff::FreeIPA::NetgroupMemberService < LdapFluff::FreeIPA::MemberService
   def find_user_groups(uid)
     groups = []
-    @ldap.search(:filter => Net::LDAP::Filter.eq('objectClass', 'nisNetgroup'), :base => @group_base).each do |entry|
+    success = @ldap.search(:filter => Net::LDAP::Filter.eq('objectClass', 'nisNetgroup'), :base => @group_base, :return_result => false) do |entry|
       members = get_netgroup_users(entry[:nisnetgrouptriple])
       groups << entry[:cn][0] if members.include? uid
+    end
+    unless success
+      raise Net::LDAP::Error, @ldap.get_operation_result[:error_message].to_s
     end
     groups
   end

--- a/lib/ldap_fluff/netiq_member_service.rb
+++ b/lib/ldap_fluff/netiq_member_service.rb
@@ -34,10 +34,15 @@ class LdapFluff::NetIQ::MemberService < LdapFluff::Posix::MemberService
       # do nothing
     end
 
-    @ldap.search(
+    results = @ldap.search(
       :filter => filter,
       :base => @group_base,
       :attributes => ['cn']
-    ).map { |entry| entry[:cn][0] }
+    )
+    if results
+      results.map { |entry| entry[:cn][0] }
+    else
+      raise Net::LDAP::Error, @ldap.get_operation_result[:error_message].to_s
+    end
   end
 end

--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -18,10 +18,16 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
   # note : this method is not particularly fast for large ldap systems
   def find_user_groups(uid)
     user = find_user(uid).first
-    @ldap.search(
+    results = @ldap.search(
       :filter => user_group_filter(uid, user[:dn].first),
       :base => @group_base, :attributes => ["cn"]
-    )&.map { |entry| entry[:cn][0] }
+    )
+
+    if results
+      results.map { |entry| entry[:cn][0] }
+    else
+      raise Net::LDAP::Error, @ldap.get_operation_result[:error_message].to_s
+    end
   end
 
   class UIDNotFoundException < LdapFluff::Error

--- a/lib/ldap_fluff/posix_member_service.rb
+++ b/lib/ldap_fluff/posix_member_service.rb
@@ -21,7 +21,7 @@ class LdapFluff::Posix::MemberService < LdapFluff::GenericMemberService
     @ldap.search(
       :filter => user_group_filter(uid, user[:dn].first),
       :base => @group_base, :attributes => ["cn"]
-    ).map { |entry| entry[:cn][0] }
+    )&.map { |entry| entry[:cn][0] }
   end
 
   class UIDNotFoundException < LdapFluff::Error

--- a/lib/ldap_fluff/posix_netgroup_member_service.rb
+++ b/lib/ldap_fluff/posix_netgroup_member_service.rb
@@ -5,9 +5,12 @@ class LdapFluff::Posix::NetgroupMemberService < LdapFluff::Posix::MemberService
   # return list of group CNs for a user
   def find_user_groups(uid)
     groups = []
-    @ldap.search(:filter => Net::LDAP::Filter.eq('objectClass', 'nisNetgroup'), :base => @group_base).each do |entry|
+    success = @ldap.search(:filter => Net::LDAP::Filter.eq('objectClass', 'nisNetgroup'), :base => @group_base, :return_result => false) do |entry|
       members = get_netgroup_users(entry[:nisnetgrouptriple])
       groups << entry[:cn][0] if members.include? uid
+    end
+    unless success
+      raise Net::LDAP::Error, @ldap.get_operation_result[:error_message].to_s
     end
     groups
   end


### PR DESCRIPTION
According to the [API documentation](https://rubydoc.info/gems/ruby-net-ldap/Net/LDAP#search-instance_method) search may return a dataset or `nil`. Calling `nil.map` will fail.

Originally reported by @lhellebr in https://issues.redhat.com/browse/SAT-24745.